### PR TITLE
Switch Rust toolchain to nightly in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: nightly
         override: true
 
     - name: Build


### PR DESCRIPTION
Updated the GitHub Actions workflow to use the nightly Rust toolchain instead of stable. This is done because the project is ment to target nightly features.